### PR TITLE
Replace llama3.1:8b with qwen3:8b

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ docker-compose up -d
 ### 3. 确保Ollama运行
 ```bash
 ollama serve
-# 确保有llama3.1:8b模型
-ollama pull llama3.1:8b
+# 确保有qwen3:8b模型
+ollama pull qwen3:8b
 ```
 
 ### 4. 运行系统
@@ -77,7 +77,7 @@ MYSQL_HOST=127.0.0.1 MYSQL_PORT=3307 MYSQL_USER=root MYSQL_PASSWORD=pass MYSQL_D
 | `MYSQL_PASSWORD` | - | MySQL密码 |
 | `MYSQL_DATABASE` | - | MySQL数据库名 |
 | `OLLAMA_BASE_URL` | http://localhost:11434 | Ollama服务地址 |
-| `OLLAMA_MODEL` | llama3.1:8b | 使用的模型 |
+| `OLLAMA_MODEL` | qwen3:8b | 使用的模型 |
 | `DB_NAME` | shop | 语义模式数据库名 |
 
 ## 语义模式定义
@@ -190,7 +190,7 @@ QUESTION="找出最活跃的用户，按订单总金额排序，显示用户名�
 ### 常见问题
 1. **Ollama连接失败**: 确保Ollama服务正在运行
 2. **MySQL连接失败**: 检查数据库配置和网络连接
-3. **模型不存在**: 使用 `ollama pull llama3.1:8b` 下载模型
+3. **模型不存在**: 使用 `ollama pull qwen3:8b` 下载模型
 4. **JSON解析错误**: 检查LLM输出格式，系统会自动清理无效条件
 
 ### 调试模式

--- a/chatbi-web/README.md
+++ b/chatbi-web/README.md
@@ -86,7 +86,7 @@ npm run dev
 ```bash
 # Ollama配置
 OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=llama3.1:8b
+OLLAMA_MODEL=qwen3:8b
 
 # MySQL配置（可选）
 MYSQL_HOST=127.0.0.1
@@ -134,7 +134,7 @@ Content-Type: application/json
   "question": "查询所有用户信息",
   "db_name": "shop",
   "use_semantic": true,
-  "model": "llama3.1:8b"
+  "model": "qwen3:8b"
 }
 ```
 

--- a/chatbi-web/backend/app.py
+++ b/chatbi-web/backend/app.py
@@ -42,7 +42,7 @@ class QueryRequest(BaseModel):
     question: str = Field(..., description="自然语言问题")
     db_name: str = Field(default="shop", description="数据库名称")
     use_semantic: bool = Field(default=True, description="是否使用语义模式")
-    model: str = Field(default="llama3.1:8b", description="使用的模型")
+    model: str = Field(default="qwen3:8b", description="使用的模型")
 
 class QueryResponse(BaseModel):
     success: bool

--- a/chatbi-web/frontend/src/components/ChatInterface.jsx
+++ b/chatbi-web/frontend/src/components/ChatInterface.jsx
@@ -11,7 +11,7 @@ function ChatInterface() {
   const [settings, setSettings] = useState({
     useSemantic: true,
     dbName: 'shop',
-    model: 'llama3.1:8b'
+    model: 'qwen3:8b'
   })
   const messagesEndRef = useRef(null)
 

--- a/chatbi-web/frontend/src/components/QueryInput.jsx
+++ b/chatbi-web/frontend/src/components/QueryInput.jsx
@@ -58,7 +58,7 @@ function QueryInput({ onSendMessage, isLoading, settings, onSettingsChange, onCl
                 onChange={(e) => handleSettingChange('model', e.target.value)}
                 className="input-field"
               >
-                <option value="llama3.1:8b">llama3.1:8b</option>
+                <option value="qwen3:8b">qwen3:8b</option>
                 <option value="qwen3:8b">qwen3:8b</option>
                 <option value="gpt-oss:20b">gpt-oss:20b</option>
               </select>

--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ def run():
         except Exception as e:
             print(f"[WARN] 无法获取数据库结构，将在无结构提示下生成: {e}")
 
-    model = os.environ.get("OLLAMA_MODEL", "llama3.1:8b")
+    model = os.environ.get("OLLAMA_MODEL", "qwen3:8b")
     base_url = os.environ.get("OLLAMA_BASE_URL")  # e.g. http://localhost:11434
     db_name = os.environ.get("DB_NAME", "shop")  # 数据库名称，用于语义模式匹配
 

--- a/semantic_example.py
+++ b/semantic_example.py
@@ -48,7 +48,7 @@ def demo_semantic_module():
             semantic, sql = nl_to_mysql(
                 question=question,
                 db_name="shop",
-                model="llama3.1:8b"
+                model="qwen3:8b"
             )
             print(f"意图: {semantic.intent}")
             print(f"SQL: {sql}")
@@ -63,7 +63,7 @@ def demo_semantic_module():
             semantic, sql = nl_to_mysql(
                 question=question,
                 db_name="unknown_db",
-                model="llama3.1:8b"
+                model="qwen3:8b"
             )
             print(f"意图: {semantic.intent}")
             print(f"SQL: {sql}")

--- a/translator.py
+++ b/translator.py
@@ -163,7 +163,7 @@ def _get_enhanced_schema_hint(
         return f"语义模式定义:\n{semantic_hint}\n\n物理表结构:\n{physical_hint}"
 
 
-def _make_llm(model: str = "llama3.1:8b", base_url: Optional[str] = None) -> ChatOllama:
+def _make_llm(model: str = "qwen3:8b", base_url: Optional[str] = None) -> ChatOllama:
     return ChatOllama(
         model=model, 
         base_url=base_url or "http://localhost:11434",
@@ -175,7 +175,7 @@ def _make_llm(model: str = "llama3.1:8b", base_url: Optional[str] = None) -> Cha
 def nl_to_semantic(
     question: str,
     schema: Optional[Dict[str, List[Tuple[str, str]]]] = None,
-    model: str = "llama3.1:8b",
+    model: str = "qwen3:8b",
     base_url: Optional[str] = None,
     db_name: str = "shop",
 ) -> SemanticSQL:
@@ -271,7 +271,7 @@ def nl_to_semantic(
 def nl_to_mysql(
     question: str,
     schema: Optional[Dict[str, List[Tuple[str, str]]]] = None,
-    model: str = "llama3.1:8b",
+    model: str = "qwen3:8b",
     base_url: Optional[str] = None,
     db_name: str = "shop",
 ) -> Tuple[SemanticSQL, str]:


### PR DESCRIPTION
Replace all instances of `llama3.1:8b` with `qwen3:8b` to switch the default and configured LLM model.

---
<a href="https://cursor.com/background-agent?bcId=bc-12eb178b-3f85-4f84-abd3-ef658f63b64e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12eb178b-3f85-4f84-abd3-ef658f63b64e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

