### PR TITLE
Replace qwen3:8b with qwen2.5:7b

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ curl -fsSL https://ollama.ai/install.sh | sh
 ollama serve
 
 # 下载模型
-ollama pull qwen3:8b
+ollama pull qwen2.5:7b
 ```
 
 #### 2. 配置MySQL（可选）
@@ -142,7 +142,7 @@ docker-compose up mysql -d
 | `MYSQL_PASSWORD` | - | MySQL密码 |
 | `MYSQL_DATABASE` | - | MySQL数据库名 |
 | `OLLAMA_BASE_URL` | http://localhost:11434 | Ollama服务地址 |
-| `OLLAMA_MODEL` | qwen3:8b | 使用的LLM模型 |
+| `OLLAMA_MODEL` | qwen2.5:7b | 使用的LLM模型 |
 | `DB_NAME` | shop | 语义模式数据库名 |
 
 #### 前端配置 (chatbi-ui)

--- a/chatbi-server/README.md
+++ b/chatbi-server/README.md
@@ -86,7 +86,7 @@ docker-compose up chatbi-server
 | `MYSQL_PASSWORD` | - | MySQL密码 |
 | `MYSQL_DATABASE` | - | MySQL数据库名 |
 | `OLLAMA_BASE_URL` | http://localhost:11434 | Ollama服务地址 |
-| `OLLAMA_MODEL` | qwen3:8b | 使用的LLM模型 |
+| `OLLAMA_MODEL` | qwen2.5:7b | 使用的LLM模型 |
 | `DB_NAME` | shop | 语义模式数据库名 |
 
 ## API接口文档
@@ -110,7 +110,7 @@ Content-Type: application/json
   "question": "查询所有用户信息",
   "db_name": "shop",
   "use_semantic": true,
-  "model": "qwen3:8b"
+  "model": "qwen2.5:7b"
 }
 ```
 
@@ -175,7 +175,7 @@ MYSQL_HOST=127.0.0.1 MYSQL_PORT=3307 MYSQL_USER=root MYSQL_PASSWORD=pass MYSQL_D
 1. **Ollama连接失败**
    - 确认Ollama服务正在运行：`ollama serve`
    - 检查OLLAMA_BASE_URL配置
-   - 确认模型已下载：`ollama pull qwen3:8b`
+   - 确认模型已下载：`ollama pull qwen2.5:7b`
 
 2. **MySQL连接失败**
    - 检查数据库服务是否运行

--- a/chatbi-server/app.py
+++ b/chatbi-server/app.py
@@ -54,7 +54,7 @@ class QueryRequest(BaseModel):
     question: str = Field(..., description="自然语言问题")
     db_name: str = Field(default="shop", description="数据库名称")
     use_semantic: bool = Field(default=True, description="是否使用语义模式")
-    model: str = Field(default="qwen3:8b", description="使用的模型")
+    model: str = Field(default="qwen2.5:7b", description="使用的模型")
 
 class QueryResponse(BaseModel):
     success: bool

--- a/chatbi-server/main.py
+++ b/chatbi-server/main.py
@@ -58,7 +58,7 @@ def run():
         except Exception as e:
             print(f"[WARN] 无法获取数据库结构，将在无结构提示下生成: {e}")
 
-    model = os.environ.get("OLLAMA_MODEL", "qwen3:8b")
+    model = os.environ.get("OLLAMA_MODEL", "qwen2.5:7b")
     base_url = os.environ.get("OLLAMA_BASE_URL")  # e.g. http://localhost:11434
     db_name = os.environ.get("DB_NAME", "shop")  # 数据库名称，用于语义模式匹配
 

--- a/chatbi-server/semantic_example.py
+++ b/chatbi-server/semantic_example.py
@@ -48,7 +48,7 @@ def demo_semantic_module():
             semantic, sql = nl_to_mysql(
                 question=question,
                 db_name="shop",
-                model="qwen3:8b"
+                model="qwen2.5:7b"
             )
             print(f"意图: {semantic.intent}")
             print(f"SQL: {sql}")
@@ -63,7 +63,7 @@ def demo_semantic_module():
             semantic, sql = nl_to_mysql(
                 question=question,
                 db_name="unknown_db",
-                model="qwen3:8b"
+                model="qwen2.5:7b"
             )
             print(f"意图: {semantic.intent}")
             print(f"SQL: {sql}")

--- a/chatbi-server/start.sh
+++ b/chatbi-server/start.sh
@@ -21,7 +21,7 @@ if ! curl -s http://localhost:11434/api/tags > /dev/null; then
     echo "⚠️  Ollama 服务未运行，请先启动 Ollama："
     echo "   ollama serve"
     echo "   然后下载模型："
-    echo "   ollama pull qwen3:8b"
+    echo "   ollama pull qwen2.5:7b"
     echo ""
     echo "继续启动服务器（可能会遇到连接错误）..."
 fi

--- a/chatbi-server/translator.py
+++ b/chatbi-server/translator.py
@@ -163,7 +163,7 @@ def _get_enhanced_schema_hint(
         return f"语义模式定义:\n{semantic_hint}\n\n物理表结构:\n{physical_hint}"
 
 
-def _make_llm(model: str = "qwen3:8b", base_url: Optional[str] = None) -> ChatOllama:
+def _make_llm(model: str = "qwen2.5:7b", base_url: Optional[str] = None) -> ChatOllama:
     return ChatOllama(
         model=model, 
         base_url=base_url or "http://localhost:11434",
@@ -175,7 +175,7 @@ def _make_llm(model: str = "qwen3:8b", base_url: Optional[str] = None) -> ChatOl
 def nl_to_semantic(
     question: str,
     schema: Optional[Dict[str, List[Tuple[str, str]]]] = None,
-    model: str = "qwen3:8b",
+    model: str = "qwen2.5:7b",
     base_url: Optional[str] = None,
     db_name: str = "shop",
 ) -> SemanticSQL:
@@ -271,7 +271,7 @@ def nl_to_semantic(
 def nl_to_mysql(
     question: str,
     schema: Optional[Dict[str, List[Tuple[str, str]]]] = None,
-    model: str = "qwen3:8b",
+    model: str = "qwen2.5:7b",
     base_url: Optional[str] = None,
     db_name: str = "shop",
 ) -> Tuple[SemanticSQL, str]:

--- a/chatbi-ui/README.md
+++ b/chatbi-ui/README.md
@@ -139,7 +139,7 @@ const result = await queryAPI({
   question: "查询所有用户信息",
   db_name: "shop",
   use_semantic: true,
-  model: "qwen3:8b"
+  model: "qwen2.5:7b"
 });
 ```
 

--- a/chatbi-ui/src/components/ChatInterface.jsx
+++ b/chatbi-ui/src/components/ChatInterface.jsx
@@ -11,7 +11,7 @@ function ChatInterface() {
   const [settings, setSettings] = useState({
     useSemantic: true,
     dbName: 'shop',
-    model: 'qwen3:8b'
+    model: 'qwen2.5:7b'
   })
   const messagesEndRef = useRef(null)
 

--- a/chatbi-ui/src/components/QueryInput.jsx
+++ b/chatbi-ui/src/components/QueryInput.jsx
@@ -58,8 +58,8 @@ function QueryInput({ onSendMessage, isLoading, settings, onSettingsChange, onCl
                 onChange={(e) => handleSettingChange('model', e.target.value)}
                 className="input-field"
               >
-                <option value="qwen3:8b">qwen3:8b</option>
-                <option value="qwen3:8b">qwen3:8b</option>
+                <option value="qwen2.5:7b">qwen2.5:7b</option>
+                <option value="qwen2.5:7b">qwen2.5:7b</option>
                 <option value="gpt-oss:20b">gpt-oss:20b</option>
               </select>
             </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - MYSQL_PASSWORD=pass
       - MYSQL_DATABASE=shop
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
-      - OLLAMA_MODEL=qwen3:8b
+      - OLLAMA_MODEL=qwen2.5:7b
     depends_on:
       mysql:
         condition: service_healthy


### PR DESCRIPTION
Replace all instances of `qwen3:8b` with `qwen2.5:7b` to update the default LLM model.

---
<a href="https://cursor.com/background-agent?bcId=bc-32101fca-c005-4976-bc72-f707d79181f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32101fca-c005-4976-bc72-f707d79181f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

